### PR TITLE
Add dockerclirc to the package-data.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         'console_scripts': 'dockercli = dockercli.main:cli'
     },
     packages=['dockercli'],
+    package_data={'dockercli': ['dockerclirc']},
     data_files=[('', ['dockerclirc'])],
     scripts=[],
     name='dockercli',


### PR DESCRIPTION
This adds the default dockerclirc template to the package data so it will be copied over when the package is installed. 

This closes #83.