### PR TITLE
Support images with colons in their names

### DIFF
--- a/dockercli/client.py
+++ b/dockercli/client.py
@@ -794,7 +794,7 @@ class DockerClient(object):
 
             # If we have more than one repo tag, return as many dicts
             for rt in a['RepoTags']:
-                repo, tag = rt.split(':', 2)
+                repo, tag = rt.rsplit(':', 1)                
                 c = {}
                 c.update(b)
                 c['Repository'] = repo


### PR DESCRIPTION
I've used docker containers that contain colons in their names, i.e. "repoUrl:9999/package/sean:latest". The split command will break in these cases.
