### PR TITLE
Support to run with DOCKER_* env variables

### DIFF
--- a/dockercli/client.py
+++ b/dockercli/client.py
@@ -8,8 +8,10 @@ import shlex
 import pretty
 import re
 import pexpect
+import ssl
 
 from docker import AutoVersionClient
+from docker import Client
 from docker.utils import kwargs_from_env, create_host_config
 from docker.errors import APIError
 from docker.errors import DockerException
@@ -119,9 +121,12 @@ class DockerClient(object):
                     raise x
         else:
             # unix-based
-            self.instance = AutoVersionClient(
-                timeout=timeout,
-                base_url='unix://var/run/docker.sock')
+            kwargs = kwargs_from_env(
+                ssl_version=ssl.PROTOCOL_TLSv1,
+                assert_hostname=False)
+            kwargs['version'] = 'auto'
+            kwargs['timeout'] = timeout
+            self.instance = Client(**kwargs)
 
     def handle_input(self, text):
         """

--- a/dockercli/client.py
+++ b/dockercli/client.py
@@ -11,7 +11,6 @@ import pexpect
 import ssl
 
 from docker import AutoVersionClient
-from docker import Client
 from docker.utils import kwargs_from_env, create_host_config
 from docker.errors import APIError
 from docker.errors import DockerException
@@ -124,9 +123,8 @@ class DockerClient(object):
             kwargs = kwargs_from_env(
                 ssl_version=ssl.PROTOCOL_TLSv1,
                 assert_hostname=False)
-            kwargs['version'] = 'auto'
             kwargs['timeout'] = timeout
-            self.instance = Client(**kwargs)
+            self.instance = AutoVersionClient(**kwargs)
 
     def handle_input(self, text):
         """


### PR DESCRIPTION
This commit allows dockercli to use the DOCKER_* variables and works with docker
remote API and Swarm, by example.